### PR TITLE
Fix persistence module build configuration and CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,22 @@ jobs:
       contents: read
       packages: write
 
+    services:
+      mysql:
+        image: mysql:8.4.5
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+          MYSQL_DATABASE: mydb
+          MYSQL_USER: dbuser
+          MYSQL_PASSWORD: dbpassword
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
     - uses: actions/checkout@v4
 
@@ -25,8 +41,27 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Wait for MySQL
+      run: |
+        until mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do
+          echo 'Waiting for MySQL...'
+          sleep 1
+        done
+        echo "MySQL is ready!"
+
+    - name: Run database migrations
+      run: ./gradlew :persistence-module:flywayMigrate
+      env:
+        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        ORG_GRADLE_PROJECT_db_user: dbuser
+        ORG_GRADLE_PROJECT_db_password: dbpassword
+
     - name: Build persistence module
       run: ./gradlew :persistence-module:build
+      env:
+        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        ORG_GRADLE_PROJECT_db_user: dbuser
+        ORG_GRADLE_PROJECT_db_password: dbpassword
 
     - name: Publish to GitHub Packages
       run: ./gradlew :persistence-module:publish

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gradle Shard Module Sample
+# Gradle Multi Module Sample
 
 Spring Boot + Flyway + jOOQ + MySQLを使用したサンプルプロジェクト
 

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -1,16 +1,18 @@
-import org.jooq.meta.jaxb.*
 
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath(Libs.Database.mysqlConnector)
         classpath(Libs.Database.flywayMysql)
+        classpath("nu.studer:gradle-jooq-plugin:10.1.1")
     }
 }
 
 plugins {
+    java
     kotlin("jvm")
     kotlin("plugin.spring")
     id("nu.studer.jooq")
@@ -65,7 +67,8 @@ jooq {
     version.set(Versions.jooq)
     
     configurations {
-        create("main") {
+        val mainConfig = create("main") as nu.studer.gradle.jooq.JooqConfig
+        mainConfig.apply {
             generateSchemaSourceOnCompilation.set(true)
             
             jooqConfiguration.apply {
@@ -95,7 +98,9 @@ jooq {
                         packageName = "com.masakaya.jooq.generated"
                         directory = "build/generated-src/jooq/main"
                     }
-                    strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                    strategy.apply {
+                        name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix jOOQ plugin configuration with proper type handling to resolve build errors
- Add MySQL service container to GitHub Actions workflow for CI builds  
- Configure database migrations and jOOQ code generation in CI pipeline

## Changes
- **CI Workflow**: Add MySQL 8.4.5 service container with health checks
- **Build Config**: Fix jOOQ plugin type inference issues with explicit casting
- **Dependencies**: Add Java plugin and update buildscript configuration
- **Database**: Configure Flyway migrations to run before jOOQ code generation

## Test plan
- [x] Build configuration compiles without type errors
- [x] GitHub Actions workflow includes MySQL service and migration steps
- [x] CI pipeline runs successfully with database-dependent build steps

🤖 Generated with [Claude Code](https://claude.ai/code)