### PR TITLE
Fix persistence module build configuration and CI/CD workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,13 +73,6 @@ jobs:
         }
         echo "MySQL and user setup complete!"
 
-    - name: Run database migrations
-      run: ./gradlew :persistence-module:flywayMigrate
-      env:
-        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-        ORG_GRADLE_PROJECT_db_user: dbuser
-        ORG_GRADLE_PROJECT_db_password: dbpassword
-
     - name: Build persistence module
       run: ./gradlew :persistence-module:build
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,22 @@ jobs:
       contents: read
       packages: write
 
+    services:
+      mysql:
+        image: mysql:8.4.5
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+          MYSQL_DATABASE: mydb
+          MYSQL_USER: dbuser
+          MYSQL_PASSWORD: dbpassword
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
     - uses: actions/checkout@v4
 
@@ -25,8 +41,27 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    - name: Wait for MySQL
+      run: |
+        until mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do
+          echo 'Waiting for MySQL...'
+          sleep 1
+        done
+        echo "MySQL is ready!"
+
+    - name: Run database migrations
+      run: ./gradlew :persistence-module:flywayMigrate
+      env:
+        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        ORG_GRADLE_PROJECT_db_user: dbuser
+        ORG_GRADLE_PROJECT_db_password: dbpassword
+
     - name: Build persistence module
       run: ./gradlew :persistence-module:build
+      env:
+        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        ORG_GRADLE_PROJECT_db_user: dbuser
+        ORG_GRADLE_PROJECT_db_password: dbpassword
 
     - name: Publish to GitHub Packages
       run: ./gradlew :persistence-module:publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,12 +73,30 @@ jobs:
         }
         echo "MySQL and user setup complete!"
 
-    - name: Run Flyway migration
-      run: ./gradlew :persistence-module:flywayMigrate
+    - name: Download Flyway CLI
+      run: |
+        wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/10.10.0/flyway-commandline-10.10.0-linux-x64.tar.gz | tar xvz
+        sudo cp flyway-10.10.0/flyway /usr/local/bin/
+        sudo chmod +x /usr/local/bin/flyway
+
+    - name: Download MySQL Connector
+      run: |
+        wget -O mysql-connector.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar
+
+    - name: Run Flyway migration with CLI
+      run: |
+        flyway \
+          -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC \
+          -user=dbuser \
+          -password=dbpassword \
+          -schemas=mydb \
+          -locations=filesystem:persistence-module/src/main/resources/db/migration \
+          -classpath=mysql-connector.jar \
+          migrate
       env:
-        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-        ORG_GRADLE_PROJECT_db_user: dbuser
-        ORG_GRADLE_PROJECT_db_password: dbpassword
+        FLYWAY_URL: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        FLYWAY_USER: dbuser
+        FLYWAY_PASSWORD: dbpassword
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,25 +73,17 @@ jobs:
         }
         echo "MySQL and user setup complete!"
 
-    - name: Download Flyway CLI
+    - name: Run Flyway migration with Docker
       run: |
-        wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/10.10.0/flyway-commandline-10.10.0-linux-x64.tar.gz | tar xvz
-        sudo cp flyway-10.10.0/flyway /usr/local/bin/
-        sudo chmod +x /usr/local/bin/flyway
-
-    - name: Download MySQL Connector
-      run: |
-        wget -O mysql-connector.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar
-
-    - name: Run Flyway migration with CLI
-      run: |
-        flyway migrate \
-          -url="jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" \
+        docker run --rm \
+          --network host \
+          -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql \
+          flyway/flyway:10.10.0 \
+          -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC \
           -user=dbuser \
           -password=dbpassword \
           -schemas=mydb \
-          -locations="filesystem:persistence-module/src/main/resources/db/migration" \
-          -classpath="mysql-connector.jar"
+          migrate
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="mysqladmin ping -h localhost"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -40,6 +40,11 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
+    - name: Install MySQL Client
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mysql-client-core-8.0
 
     - name: Wait for MySQL
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
           MYSQL_DATABASE: mydb
-          MYSQL_USER: dbuser
-          MYSQL_PASSWORD: dbpassword
         ports:
           - 3306:3306
         options: >-
@@ -44,13 +42,13 @@ jobs:
     - name: Install MySQL Client
       run: |
         sudo apt-get update
-        sudo apt-get install -y mysql-client-core-8.0
+        sudo apt-get install -y mysql-client-8.0
 
-    - name: Wait for MySQL
+    - name: Wait for MySQL and create user
       run: |
         echo "Waiting for MySQL service to be ready..."
         for i in {1..30}; do
-          if mysqladmin ping -h"127.0.0.1" -P"3306" -u"dbuser" -p"dbpassword" --silent; then
+          if mysqladmin ping -h"127.0.0.1" -P"3306" -u"root" -p"rootpassword" --silent; then
             echo "MySQL is ready!"
             break
           else
@@ -59,12 +57,21 @@ jobs:
           fi
         done
         
-        # Verify connection one more time
-        echo "Final connection test..."
+        # Create database user
+        echo "Creating database user..."
+        mysql -h"127.0.0.1" -P"3306" -u"root" -p"rootpassword" -e "
+          CREATE USER IF NOT EXISTS 'dbuser'@'%' IDENTIFIED BY 'dbpassword';
+          GRANT ALL PRIVILEGES ON mydb.* TO 'dbuser'@'%';
+          FLUSH PRIVILEGES;
+        "
+        
+        # Verify user connection
+        echo "Testing user connection..."
         mysqladmin ping -h"127.0.0.1" -P"3306" -u"dbuser" -p"dbpassword" --silent || {
-          echo "ERROR: Could not connect to MySQL"
+          echo "ERROR: Could not connect to MySQL with dbuser"
           exit 1
         }
+        echo "MySQL and user setup complete!"
 
     - name: Run database migrations
       run: ./gradlew :persistence-module:flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,18 +85,13 @@ jobs:
 
     - name: Run Flyway migration with CLI
       run: |
-        flyway \
-          -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC \
+        flyway migrate \
+          -url="jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" \
           -user=dbuser \
           -password=dbpassword \
           -schemas=mydb \
-          -locations=filesystem:persistence-module/src/main/resources/db/migration \
-          -classpath=mysql-connector.jar \
-          migrate
-      env:
-        FLYWAY_URL: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-        FLYWAY_USER: dbuser
-        FLYWAY_PASSWORD: dbpassword
+          -locations="filesystem:persistence-module/src/main/resources/db/migration" \
+          -classpath="mysql-connector.jar"
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,8 +73,15 @@ jobs:
         }
         echo "MySQL and user setup complete!"
 
-    - name: Build persistence module
-      run: ./gradlew :persistence-module:build
+    - name: Run Flyway migration
+      run: ./gradlew :persistence-module:flywayMigrate
+      env:
+        ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+        ORG_GRADLE_PROJECT_db_user: dbuser
+        ORG_GRADLE_PROJECT_db_password: dbpassword
+
+    - name: Build persistence module (skip Flyway)
+      run: ./gradlew :persistence-module:build -x flywayMigrate
       env:
         ORG_GRADLE_PROJECT_db_url: jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
         ORG_GRADLE_PROJECT_db_user: dbuser

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,15 +75,7 @@ jobs:
 
     - name: Run Flyway migration with Docker
       run: |
-        docker run --rm \
-          --network host \
-          -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql \
-          flyway/flyway:10.10.0 \
-          -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC \
-          -user=dbuser \
-          -password=dbpassword \
-          -schemas=mydb \
-          migrate
+        docker run --rm --network host -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql flyway/flyway:10.10.0 -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC -user=dbuser -password=dbpassword -schemas=mydb migrate
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,7 @@ jobs:
 
     - name: Run Flyway migration with Docker
       run: |
+        echo "Starting Flyway migration with Docker..."
         docker run --rm --network host \
           -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql \
           -e FLYWAY_URL="jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" \
@@ -82,6 +83,12 @@ jobs:
           -e FLYWAY_PASSWORD=dbpassword \
           -e FLYWAY_SCHEMAS=mydb \
           flyway/flyway:10.10.0 migrate
+        echo "Flyway migration completed successfully!"
+        
+    - name: Verify migration results
+      run: |
+        echo "Checking migration results..."
+        mysql -h"127.0.0.1" -P"3306" -u"dbuser" -p"dbpassword" mydb -e "SHOW TABLES;"
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate
@@ -91,7 +98,7 @@ jobs:
         ORG_GRADLE_PROJECT_db_password: dbpassword
 
     - name: Publish to GitHub Packages
-      run: ./gradlew :persistence-module:publish
+      run: ./gradlew :persistence-module:publish -x flywayMigrate
       env:
         USERNAME: ${{ github.actor }}
         TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h localhost"
+          --health-cmd="mysqladmin ping -h localhost -u root -prootpassword"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
+          --health-timeout=10s
+          --health-retries=10
 
     steps:
     - uses: actions/checkout@v4
@@ -48,11 +48,23 @@ jobs:
 
     - name: Wait for MySQL
       run: |
-        until mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do
-          echo 'Waiting for MySQL...'
-          sleep 1
+        echo "Waiting for MySQL service to be ready..."
+        for i in {1..30}; do
+          if mysqladmin ping -h"127.0.0.1" -P"3306" -u"dbuser" -p"dbpassword" --silent; then
+            echo "MySQL is ready!"
+            break
+          else
+            echo "Attempt $i/30: MySQL not ready yet, waiting 5 seconds..."
+            sleep 5
+          fi
         done
-        echo "MySQL is ready!"
+        
+        # Verify connection one more time
+        echo "Final connection test..."
+        mysqladmin ping -h"127.0.0.1" -P"3306" -u"dbuser" -p"dbpassword" --silent || {
+          echo "ERROR: Could not connect to MySQL"
+          exit 1
+        }
 
     - name: Run database migrations
       run: ./gradlew :persistence-module:flywayMigrate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,13 @@ jobs:
 
     - name: Run Flyway migration with Docker
       run: |
-        docker run --rm --network host -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql flyway/flyway:10.10.0 -url=jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC -user=dbuser -password=dbpassword -schemas=mydb migrate
+        docker run --rm --network host \
+          -v ${{ github.workspace }}/persistence-module/src/main/resources/db/migration:/flyway/sql \
+          -e FLYWAY_URL="jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" \
+          -e FLYWAY_USER=dbuser \
+          -e FLYWAY_PASSWORD=dbpassword \
+          -e FLYWAY_SCHEMAS=mydb \
+          flyway/flyway:10.10.0 migrate
 
     - name: Build persistence module (skip Flyway)
       run: ./gradlew :persistence-module:build -x flywayMigrate

--- a/README.md
+++ b/README.md
@@ -133,7 +133,27 @@ docker exec mysql-db mysql -udbuser -pdbpassword -e "SELECT 1;"
 ls -la persistence-module/build/generated-src/jooq/main/
 ```
 
-### 6. アプリケーション起動
+### 6. persistence-moduleのビルド（ローカル）
+
+**注意**: Flywayプラグインの制約により、ローカルでは手動でマイグレーションを実行してからビルドします。
+
+```bash
+# 手動でマイグレーション実行
+docker exec -i mysql-db mysql -uroot -prootpassword mydb < persistence-module/src/main/resources/db/migration/V1__create_companies_table.sql
+docker exec -i mysql-db mysql -uroot -prootpassword mydb < persistence-module/src/main/resources/db/migration/V2__create_teams_table.sql  
+docker exec -i mysql-db mysql -uroot -prootpassword mydb < persistence-module/src/main/resources/db/migration/V3__create_users_table.sql
+
+# jOOQクラス生成（Flywayスキップ）
+./gradlew :persistence-module:generateJooq -x flywayMigrate
+
+# persistence-moduleビルド（Flywayスキップ）
+./gradlew :persistence-module:build -x flywayMigrate
+
+# ローカルパブリッシュテスト
+./gradlew :persistence-module:publishToMavenLocal -x flywayMigrate
+```
+
+### 7. アプリケーション起動
 
 ```bash
 # app-moduleから起動（開発環境：マイグレーション + テストデータ投入）
@@ -146,7 +166,7 @@ ls -la persistence-module/build/generated-src/jooq/main/
 ./gradlew :app-module:bootRun
 ```
 
-### 7. 動作確認
+### 8. 動作確認
 
 ```bash
 # APIエンドポイント確認

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gradle Shard Module Sample
+# Gradle Multi Module Sample
 
 Spring Boot + Flyway + jOOQ + MySQLを使用したサンプルプロジェクト
 

--- a/app-module/src/main/resources/application.yml
+++ b/app-module/src/main/resources/application.yml
@@ -22,6 +22,7 @@ spring:
   # Flyway設定
   flyway:
     validate-on-migrate: false
+    baseline-on-migrate: true
     
   # 国際化設定（MessageConfigで設定）
   

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath(Libs.Database.mysqlConnector)
+        classpath(Libs.Database.flyway)
         classpath(Libs.Database.flywayMysql)
         classpath("nu.studer:gradle-jooq-plugin:10.1.1")
     }

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -212,7 +212,7 @@ publishing {
             pom {
                 name.set("Infrastructure Persistence Module")
                 description.set("Shared persistence layer for database operations")
-                url.set("https://github.com/masakaya/gradle-shard-module-sample")
+                url.set("https://github.com/masakaya/gradle-multi-module-sample")
                 
                 licenses {
                     license {
@@ -230,9 +230,9 @@ publishing {
                 }
                 
                 scm {
-                    connection.set("scm:git:git://github.com/masakaya/gradle-shard-module-sample.git")
-                    developerConnection.set("scm:git:ssh://github.com/masakaya/gradle-shard-module-sample.git")
-                    url.set("https://github.com/masakaya/gradle-shard-module-sample")
+                    connection.set("scm:git:git://github.com/masakaya/gradle-multi-module-sample.git")
+                    developerConnection.set("scm:git:ssh://github.com/masakaya/gradle-multi-module-sample.git")
+                    url.set("https://github.com/masakaya/gradle-multi-module-sample")
                 }
             }
         }
@@ -241,7 +241,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/masakaya/gradle-shard-module-sample")
+            url = uri("https://maven.pkg.github.com/masakaya/gradle-multi-module-sample")
             credentials {
                 username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
                 password = project.findProperty("gpr.key") as String? ?: System.getenv("TOKEN")

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -125,9 +125,12 @@ flyway {
     cleanDisabled = false
 }
 
-// Configure Flyway tasks to use MySQL driver
-tasks.withType<org.flywaydb.gradle.task.AbstractFlywayTask>().configureEach {
-    dependsOn(configurations.runtimeClasspath)
+// Configure Flyway tasks to ensure MySQL driver is available
+tasks.named("flywayMigrate") {
+    dependsOn("classes")
+    doFirst {
+        println("Flyway migrate using: $dbUrl")
+    }
 }
 
 tasks.named("generateJooq").configure {

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -59,9 +59,23 @@ kotlin {
 }
 
 // Database connection configuration (for jOOQ code generation)
-val dbUrl = project.findProperty("db.url") as String? ?: "jdbc:mysql://localhost:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
-val dbUser = project.findProperty("db.user") as String? ?: "dbuser"
-val dbPassword = project.findProperty("db.password") as String? ?: "dbpassword"
+val dbUrl = project.findProperty("db.url") as String? 
+    ?: System.getenv("ORG_GRADLE_PROJECT_db_url") 
+    ?: "jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
+val dbUser = project.findProperty("db.user") as String? 
+    ?: System.getenv("ORG_GRADLE_PROJECT_db_user") 
+    ?: "dbuser"
+val dbPassword = project.findProperty("db.password") as String? 
+    ?: System.getenv("ORG_GRADLE_PROJECT_db_password") 
+    ?: "dbpassword"
+
+// Debug logging for database configuration
+println("=== Database Configuration ===")
+println("dbUrl: $dbUrl")
+println("dbUser: $dbUser")
+println("Environment ORG_GRADLE_PROJECT_db_url: ${System.getenv("ORG_GRADLE_PROJECT_db_url")}")
+println("Project property db.url: ${project.findProperty("db.url")}")
+println("==============================")
 
 // jOOQ configuration
 jooq {

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
     }
 }
 
+
 plugins {
     java
     kotlin("jvm")
@@ -47,6 +48,11 @@ dependencies {
     // MySQL driver needs to be available at multiple classpaths for Flyway and jOOQ
     implementation(Libs.Database.mysqlConnector)
     runtimeOnly(Libs.Database.mysqlConnector)  // For Flyway runtime
+    
+    // Special Flyway classpath configuration
+    add("flywayClasspath", Libs.Database.mysqlConnector)
+    add("flywayClasspath", Libs.Database.flywayMysql)
+    
     jooqGenerator(Libs.Database.mysqlConnector)
     jooqGenerator(Libs.Jooq.codegen)
     

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -44,8 +44,9 @@ dependencies {
     api(Libs.Database.flywayMysql)
     api(Libs.Kotlin.reflect)
     
-    // MySQL driver needs to be available at compile time for Flyway
+    // MySQL driver needs to be available at multiple classpaths for Flyway and jOOQ
     implementation(Libs.Database.mysqlConnector)
+    runtimeOnly(Libs.Database.mysqlConnector)  // For Flyway runtime
     jooqGenerator(Libs.Database.mysqlConnector)
     jooqGenerator(Libs.Jooq.codegen)
     
@@ -120,6 +121,7 @@ flyway {
     url = dbUrl
     user = dbUser
     password = dbPassword
+    driver = "com.mysql.cj.jdbc.Driver"  // Explicitly specify the MySQL driver
     schemas = arrayOf("mydb")
     locations = arrayOf("filesystem:src/main/resources/db/migration")
     cleanDisabled = false
@@ -150,7 +152,7 @@ tasks.named("flywayMigrate") {
         println("java.class.path contains mysql: ${System.getProperty("java.class.path").contains("mysql")}")
         
         println("=== End Debug Info ===")
-    }
+
 }
 
 tasks.named("generateJooq").configure {

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -127,13 +127,13 @@ flyway {
 
 // Configure Flyway tasks to ensure MySQL driver is available
 tasks.named("flywayMigrate") {
-    dependsOn("classes")
     doFirst {
         println("Flyway migrate using: $dbUrl")
     }
 }
 
 tasks.named("generateJooq").configure {
+    dependsOn("flywayMigrate")
     inputs.dir("src/main/resources/db/migration")
     outputs.dir("build/generated-src/jooq")
     
@@ -141,6 +141,11 @@ tasks.named("generateJooq").configure {
         println("Generating jOOQ classes from database schema...")
         println("Make sure the database is running and migrations are applied!")
     }
+}
+
+// Ensure compileKotlin runs after jOOQ code generation
+tasks.named("compileKotlin").configure {
+    dependsOn("generateJooq")
 }
 
 // GitHub Packages publishing configuration

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -128,7 +128,28 @@ flyway {
 // Configure Flyway tasks to ensure MySQL driver is available
 tasks.named("flywayMigrate") {
     doFirst {
-        println("Flyway migrate using: $dbUrl")
+        println("=== Flyway Migration Debug Info ===")
+        println("Database URL: $dbUrl")
+        println("Database User: $dbUser") 
+        println("Database Password: ${if (dbPassword.isNotEmpty()) "***SET***" else "***EMPTY***"}")
+        println("Flyway schemas: ${flyway.schemas.joinToString(", ")}")
+        println("Flyway locations: ${flyway.locations.joinToString(", ")}")
+        
+        // Check buildscript classpath
+        println("=== Buildscript Classpath Info ===")
+        try {
+            val mysqlDriverClass = Class.forName("com.mysql.cj.jdbc.Driver")
+            println("MySQL Driver found in classpath: ${mysqlDriverClass.canonicalName}")
+        } catch (e: ClassNotFoundException) {
+            println("ERROR: MySQL Driver NOT found in classpath!")
+            println("ClassNotFoundException: ${e.message}")
+        }
+        
+        // Print system properties
+        println("=== Java System Properties ===")
+        println("java.class.path contains mysql: ${System.getProperty("java.class.path").contains("mysql")}")
+        
+        println("=== End Debug Info ===")
     }
 }
 

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -1,16 +1,18 @@
-import org.jooq.meta.jaxb.*
 
 buildscript {
     repositories {
         mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         classpath(Libs.Database.mysqlConnector)
         classpath(Libs.Database.flywayMysql)
+        classpath("nu.studer:gradle-jooq-plugin:10.1.1")
     }
 }
 
 plugins {
+    java
     kotlin("jvm")
     kotlin("plugin.spring")
     id("nu.studer.jooq")
@@ -65,7 +67,8 @@ jooq {
     version.set(Versions.jooq)
     
     configurations {
-        create("main") {
+        val mainConfig = create("main") as nu.studer.gradle.jooq.JooqConfig
+        mainConfig.apply {
             generateSchemaSourceOnCompilation.set(true)
             
             jooqConfiguration.apply {
@@ -95,7 +98,9 @@ jooq {
                         packageName = "com.masakaya.jooq.generated"
                         directory = "build/generated-src/jooq/main"
                     }
-                    strategy.name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                    strategy.apply {
+                        name = "org.jooq.codegen.DefaultGeneratorStrategy"
+                    }
                 }
             }
         }

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -59,23 +59,15 @@ kotlin {
 }
 
 // Database connection configuration (for jOOQ code generation)
-val dbUrl = project.findProperty("db.url") as String? 
-    ?: System.getenv("ORG_GRADLE_PROJECT_db_url") 
+val dbUrl = System.getenv("ORG_GRADLE_PROJECT_db_url") 
+    ?: project.findProperty("db.url") as String?
     ?: "jdbc:mysql://127.0.0.1:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
-val dbUser = project.findProperty("db.user") as String? 
-    ?: System.getenv("ORG_GRADLE_PROJECT_db_user") 
+val dbUser = System.getenv("ORG_GRADLE_PROJECT_db_user")
+    ?: project.findProperty("db.user") as String?
     ?: "dbuser"
-val dbPassword = project.findProperty("db.password") as String? 
-    ?: System.getenv("ORG_GRADLE_PROJECT_db_password") 
+val dbPassword = System.getenv("ORG_GRADLE_PROJECT_db_password")
+    ?: project.findProperty("db.password") as String?
     ?: "dbpassword"
-
-// Debug logging for database configuration
-println("=== Database Configuration ===")
-println("dbUrl: $dbUrl")
-println("dbUser: $dbUser")
-println("Environment ORG_GRADLE_PROJECT_db_url: ${System.getenv("ORG_GRADLE_PROJECT_db_url")}")
-println("Project property db.url: ${project.findProperty("db.url")}")
-println("==============================")
 
 // jOOQ configuration
 jooq {

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -49,10 +49,6 @@ dependencies {
     implementation(Libs.Database.mysqlConnector)
     runtimeOnly(Libs.Database.mysqlConnector)  // For Flyway runtime
     
-    // Special Flyway classpath configuration
-    add("flywayClasspath", Libs.Database.mysqlConnector)
-    add("flywayClasspath", Libs.Database.flywayMysql)
-    
     jooqGenerator(Libs.Database.mysqlConnector)
     jooqGenerator(Libs.Jooq.codegen)
     
@@ -162,7 +158,10 @@ tasks.named("flywayMigrate") {
 }
 
 tasks.named("generateJooq").configure {
-    dependsOn("flywayMigrate")
+    // Only depend on flywayMigrate when not excluded
+    if (project.gradle.startParameter.excludedTaskNames.none { it.contains("flywayMigrate") }) {
+        dependsOn("flywayMigrate")
+    }
     inputs.dir("src/main/resources/db/migration")
     outputs.dir("build/generated-src/jooq")
     

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -44,7 +44,8 @@ dependencies {
     api(Libs.Database.flywayMysql)
     api(Libs.Kotlin.reflect)
     
-    runtimeOnly(Libs.Database.mysqlConnector)
+    // MySQL driver needs to be available at compile time for Flyway
+    implementation(Libs.Database.mysqlConnector)
     jooqGenerator(Libs.Database.mysqlConnector)
     jooqGenerator(Libs.Jooq.codegen)
     
@@ -122,6 +123,11 @@ flyway {
     schemas = arrayOf("mydb")
     locations = arrayOf("filesystem:src/main/resources/db/migration")
     cleanDisabled = false
+}
+
+// Configure Flyway tasks to use MySQL driver
+tasks.withType<org.flywaydb.gradle.task.AbstractFlywayTask>().configureEach {
+    dependsOn(configurations.runtimeClasspath)
 }
 
 tasks.named("generateJooq").configure {

--- a/persistence-module/build.gradle.kts
+++ b/persistence-module/build.gradle.kts
@@ -152,7 +152,7 @@ tasks.named("flywayMigrate") {
         println("java.class.path contains mysql: ${System.getProperty("java.class.path").contains("mysql")}")
         
         println("=== End Debug Info ===")
-
+    }
 }
 
 tasks.named("generateJooq").configure {


### PR DESCRIPTION
## Summary
- Fixed persistence module build configuration issues with jOOQ and Flyway
- Resolved GitHub Actions CI/CD workflow for automated testing and publishing  
- Added comprehensive local development workflow documentation
- Successfully integrated Docker Flyway container approach for reliable migrations

## Key Changes
- **GitHub Actions**: Added MySQL service container and Docker Flyway migration
- **Persistence Module**: Fixed jOOQ plugin type inference and task dependencies
- **Application Configuration**: Added baseline-on-migrate for Flyway schema history
- **Repository Configuration**: Corrected GitHub Packages repository name
- **Documentation**: Updated README with comprehensive local development workflow

## Test Plan
- [x] Local persistence module build with `./gradlew :persistence-module:build -x flywayMigrate`
- [x] Local Maven publishing with `./gradlew :persistence-module:publishToMavenLocal -x flywayMigrate`
- [x] GitHub Actions CI/CD pipeline execution
- [x] GitHub Packages publishing verification
- [x] Spring Boot application startup with health check

🤖 Generated with [Claude Code](https://claude.ai/code)